### PR TITLE
Fix params types for post editing

### DIFF
--- a/src/app/(authorized)/posts/create/page.tsx
+++ b/src/app/(authorized)/posts/create/page.tsx
@@ -1,15 +1,7 @@
 import { Suspense } from "react";
 import { PostList } from "../list/_components/PostList/index.server";
-import { getPost } from "@/domains/posts/repository/getPost";
 
-type Props = {
-  params: { id: string };
-};
-
-export default async function Posts({ params }: Props) {
-  const id = (await params).id;
-  const post = await getPost(id);
-
+export default function Posts() {
   return (
     <Suspense>
       <PostList />

--- a/src/app/(authorized)/posts/edit/[id]/_actions/server/generateFormValue/index.ts
+++ b/src/app/(authorized)/posts/edit/[id]/_actions/server/generateFormValue/index.ts
@@ -1,11 +1,11 @@
 import { getPost } from "@/domains/posts/repository/getPost";
 
 type Props = {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 };
 
 export const generateFormValue = async ({ params }: Props) => {
-  const id = (await params).id;
+  const id = params.id;
   const post = await getPost(id);
   const defaultValues = post ?? {
     userId: 0,

--- a/src/app/(authorized)/posts/edit/[id]/page.tsx
+++ b/src/app/(authorized)/posts/edit/[id]/page.tsx
@@ -2,7 +2,7 @@ import { PageContent } from "./_components/PageContent/index.client";
 import { generateFormValue } from "./_actions/server/generateFormValue";
 
 type Props = {
-  params: Promise<{ id: string }>;
+  params: { id: string };
 };
 
 export default async function EditPost({ params }: Props) {


### PR DESCRIPTION
## Summary
- fix parameter types in post edit server action and page
- simplify create page example

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846cd775f88832bad5128aebf45fb45